### PR TITLE
Add missing “core-pages” dep to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "google-apis": "GoogleWebComponents/google-apis#master",
     "cool-clock": "Polymer/cool-clock#master",
     "polymer-stock": "Polymer/polymer-stock#master",
-    "wu-weather": "Polymer/wu-weather#master"
+    "wu-weather": "Polymer/wu-weather#master",
+    "core-pages": "Polymer/core-pages#master"
   }
 }


### PR DESCRIPTION
elements/pi-app.html requires “core-pages”, and so it should be included
in the deps in bower.json.
